### PR TITLE
Add ability to have multiple grids for a data set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Comrade"
 uuid = "99d987ce-9a1e-4df8-bc0b-1ea019aa547b"
 authors = ["Paul Tiede <ptiede91@gmail.com>"]
-version = "0.11.12"
+version = "0.11.13"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -87,6 +87,7 @@ Comrade.Coherencies
 Comrade.AbstractSkyModel
 Comrade.SkyModel
 Comrade.FixedSkyModel
+Comrade.MultiSkyModel
 Comrade.idealvisibilities
 Comrade.skymodel(::Comrade.AbstractVLBIPosterior, ::Any)
 ```

--- a/src/Comrade.jl
+++ b/src/Comrade.jl
@@ -65,7 +65,7 @@ import ComradeBase: flux, radialextent, intensitymap, intensitymap!,
     amplitudemap
 include("observations/observations.jl")
 include("instrument/instrument.jl")
-include("skymodels/models.jl")
+include("skymodels/abstract.jl")
 include("posterior/abstract.jl")
 include("inference/inference.jl")
 include("visualizations/visualizations.jl")

--- a/src/posterior/vlbiposterior.jl
+++ b/src/posterior/vlbiposterior.jl
@@ -1,4 +1,4 @@
-struct VLBIPosterior{D, T, P, MS <: ObservedSkyModel, MI <: AbstractInstrumentModel, ADMode <: Union{Nothing, EnzymeCore.Mode}} <: AbstractVLBIPosterior
+struct VLBIPosterior{D, T, P, MS <: AbstractSkyModel, MI <: AbstractInstrumentModel, ADMode <: Union{Nothing, EnzymeCore.Mode}} <: AbstractVLBIPosterior
     data::D
     lklhds::T
     prior::P

--- a/src/skymodels/abstract.jl
+++ b/src/skymodels/abstract.jl
@@ -1,0 +1,75 @@
+"""
+    AbstractSkyModel
+
+The abstract type for Comrade Sky Models. For a concrete implementation see [`SkyModel`](@ref).
+
+Any subtype must implement the following methods
+ - `ObservedSkyModel(m::AbstractSkyModel, array::AbstractArrayConfiguration)`: Constructs an observed sky model
+    given the sky model `m` and the array configuration `array`. This method is used to compute the visibilities
+    and image of the sky model.
+
+The following methods have default implementations:
+ - `idealvisibilities(m::AbstractSkyModel, x)`: Computes the ideal visibilities of the sky model `m`
+    given the model parameters `x`.
+ - `skymodel(m::AbstractSkyModel, x)`: Returns the sky model image given the model parameters `x`.
+ - `domain(m::AbstractSkyModel)`: Returns the domain of the sky model `m`.
+ - `set_array(m::AbstractSkyModel, array::AbstractArrayConfiguration)`: Sets the array configuration
+    for the sky model `m` and returns the observed sky model and prior.
+ - `set_prior(m::AbstractSkyModel, array::AbstractArrayConfiguration)`: Sets the prior for the sky model
+    `m` given the array configuration `array`. This is used to set the priors for the model parameters.
+
+"""
+abstract type AbstractSkyModel end
+
+function Base.show(io::IO, mime::MIME"text/plain", m::AbstractSkyModel)
+    T = typeof(m)
+    ST = split(split(" $T", '{')[1], ".")[end]
+    printstyled(io, ST; bold = true, color = :blue)
+    println(io)
+    println(io, "  with map: $(skymodel(m))")
+    # GT = typeof(domain(m))
+    # SGT = split("$GT", '{')[1]
+    print(io, "   on grid: \n")
+    show(io, mime, domain(m))
+    print(io, "\n   )\n")
+end
+
+skymodel(m::AbstractSkyModel) = getfield(m, :f)
+
+
+function set_array(m::AbstractSkyModel, array::AbstractArrayConfiguration)
+    return ObservedSkyModel(m, array), set_prior(m, array)
+end
+
+function domain(m::AbstractSkyModel; kwargs...)
+    return getfield(m, :grid)
+end
+
+"""
+    idealvisibilities(m::AbstractSkyModel, x)
+
+Computes the ideal non-corrupted visibilities of the sky model `m` given the model parameters `x`.
+"""
+function idealvisibilities(m::AbstractSkyModel, x)
+    skym = skymodel(m, x.sky)
+    return visibilitymap(skym, domain(m))
+end
+
+function skymodel(m::AbstractSkyModel, x)
+    return m.f(x, m.metadata)
+end
+
+function set_prior(m::AbstractSkyModel, array::AbstractArrayConfiguration)
+    return getfield(m, :prior)
+end
+
+struct ObservedSkyModel{F, G <: VLBISkyModels.AbstractDomain, M} <: AbstractSkyModel
+    f::F
+    grid::G
+    metadata::M
+end
+
+
+include("models.jl")
+include("fixed.jl")
+include("multi.jl")

--- a/src/skymodels/abstract.jl
+++ b/src/skymodels/abstract.jl
@@ -31,7 +31,7 @@ function Base.show(io::IO, mime::MIME"text/plain", m::AbstractSkyModel)
     # SGT = split("$GT", '{')[1]
     print(io, "   on grid: \n")
     show(io, mime, domain(m))
-    print(io, "\n   )\n")
+    return print(io, "\n   )\n")
 end
 
 skymodel(m::AbstractSkyModel) = getfield(m, :f)

--- a/src/skymodels/fixed.jl
+++ b/src/skymodels/fixed.jl
@@ -1,0 +1,48 @@
+"""
+    FixedSkyModel(m::AbstractModel, grid::AbstractRectiGrid; algorithm = NFFTAlg())
+
+Construct a sky model that has no free parameters. This is useful for models where the
+image structure is known apriori but the instrument model is unknown.
+
+# Arguments
+
+ - `m` : The fixed sky model.
+- `grid` : The domain on which the model is defined. This defines the field of view and resolution
+   of the model. Note that if `f` produces a analytic model then this field of view isn't used
+   directly in the computation of the visibilities.
+
+# Optional Arguments
+- `algorithm` : The Fourier transform algorithm used to compute the visibilities. The default is
+   `NFFTAlg()` which uses a non-uniform fast Fourier transform. Other options can be found by using
+   `subtypes(VLBISkyModels.FourierTransform)`
+"""
+Base.@kwdef struct FixedSkyModel{M <: AbstractModel, G, A <: FourierTransform} <: AbstractSkyModel
+    model::M
+    grid::G
+    algorithm::A = NFFTAlg()
+end
+
+skymodel(m::FixedSkyModel) = m.model
+
+function FixedSkyModel(m::AbstractModel, grid::AbstractRectiGrid; algorithm = NFFTAlg())
+    return FixedSkyModel(m, grid, algorithm)
+end
+
+function ObservedSkyModel(m::FixedSkyModel, arr::AbstractArrayConfiguration)
+    gfour = FourierDualDomain(m.grid, arr, m.algorithm)
+    img = intensitymap(m.model, gfour)
+    vis = visibilitymap(m.model, gfour)
+    return ObservedSkyModel(m, gfour, (; img, vis))
+end
+
+function set_prior(::FixedSkyModel, ::AbstractArrayConfiguration)
+    return NamedTuple()
+end
+
+function idealvisibilities(m::ObservedSkyModel{<:FixedSkyModel}, x)
+    return m.metadata.vis
+end
+
+function skymodel(m::ObservedSkyModel{<:FixedSkyModel}, x)
+    return m.f.model
+end

--- a/src/skymodels/models.jl
+++ b/src/skymodels/models.jl
@@ -1,24 +1,6 @@
 export SkyModel, FixedSkyModel
 
 
-"""
-    AbstractSkyModel
-
-The abstract type for Comrade Sky Models. For a concrete implementation see [`SkyModel`](@ref).
-
-Any subtype must implement the following methods
-
- - `set_array(m::AbstractSkyModel, array::AbstractArrayConfiguration)`: Sets the array configuration
-    for the sky model `m` and returns the observed sky model and prior.
-
-The following methods have default implementations:
- - `idealvisibilities(m::AbstractSkyModel, x)`: Computes the ideal visibilities of the sky model `m`
-    given the model parameters `x`.
- - `skymodel(m::AbstractSkyModel, x)`: Returns the sky model image given the model parameters `x`.
- - `domain(m::AbstractSkyModel)`: Returns the domain of the sky model `m`.
-"""
-abstract type AbstractSkyModel end
-
 
 struct SkyModel{F, P, G <: AbstractDomain, A <: FourierTransform, M} <: AbstractSkyModel
     f::F
@@ -28,16 +10,6 @@ struct SkyModel{F, P, G <: AbstractDomain, A <: FourierTransform, M} <: Abstract
     metadata::M
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", m::AbstractSkyModel)
-    T = typeof(m)
-    ST = split(split(" $T", '{')[1], ".")[end]
-    printstyled(io, ST; bold = true, color = :blue)
-    println(io)
-    println(io, "  with map: $(m.f)")
-    GT = typeof(m.grid)
-    SGT = split("$GT", '{')[1]
-    return print(io, "   on grid: $SGT")
-end
 
 """
     SkyModel(f, prior, grid::AbstractRectiGrid; algorithm = NFFTAlg(), metadata=nothing)
@@ -72,15 +44,7 @@ function VLBISkyModels.FourierDualDomain(grid::AbstractRectiGrid, array::Abstrac
     return FourierDualDomain(grid, domain(array; executor), alg)
 end
 
-struct ObservedSkyModel{F, G <: VLBISkyModels.AbstractDomain, M} <: AbstractSkyModel
-    f::F
-    grid::G
-    metadata::M
-end
 
-function domain(m::AbstractSkyModel; kwargs...)
-    return getfield(m, :grid)
-end
 
 # If we are using a analytic model then we don't need to plan the FT and we
 # can save some memory by not storing the plans.
@@ -109,70 +73,4 @@ function ObservedSkyModel(m::SkyModel, arr::AbstractArrayConfiguration)
         g = FourierDualDomain(m.grid, arr, m.algorithm)
     end
     return ObservedSkyModel(m.f, g, m.metadata)
-end
-
-
-function set_array(m::AbstractSkyModel, array::AbstractArrayConfiguration)
-    return ObservedSkyModel(m, array), m.prior
-end
-
-"""
-    idealvisibilities(m::AbstractSkyModel, x)
-
-Computes the ideal non-corrupted visibilities of the sky model `m` given the model parameters `x`.
-"""
-function idealvisibilities(m::AbstractSkyModel, x)
-    skym = skymodel(m, x.sky)
-    return visibilitymap(skym, domain(m))
-end
-
-function skymodel(m::AbstractSkyModel, x)
-    return m.f(x, m.metadata)
-end
-
-"""
-    FixedSkyModel(m::AbstractModel, grid::AbstractRectiGrid; algorithm = NFFTAlg())
-
-Construct a sky model that has no free parameters. This is useful for models where the
-image structure is known apriori but the instrument model is unknown.
-
-# Arguments
-
- - `m` : The fixed sky model.
-- `grid` : The domain on which the model is defined. This defines the field of view and resolution
-   of the model. Note that if `f` produces a analytic model then this field of view isn't used
-   directly in the computation of the visibilities.
-
-# Optional Arguments
-- `algorithm` : The Fourier transform algorithm used to compute the visibilities. The default is
-   `NFFTAlg()` which uses a non-uniform fast Fourier transform. Other options can be found by using
-   `subtypes(VLBISkyModels.FourierTransform)`
-"""
-Base.@kwdef struct FixedSkyModel{M <: AbstractModel, G, A <: FourierTransform} <: AbstractSkyModel
-    model::M
-    grid::G
-    algorithm::A = NFFTAlg()
-end
-
-function FixedSkyModel(m::AbstractModel, grid::AbstractRectiGrid; algorithm = NFFTAlg())
-    return FixedSkyModel(m, grid, algorithm)
-end
-
-function ObservedSkyModel(m::FixedSkyModel, arr::AbstractArrayConfiguration)
-    gfour = FourierDualDomain(m.grid, arr, m.algorithm)
-    img = intensitymap(m.model, gfour)
-    vis = visibilitymap(m.model, gfour)
-    return ObservedSkyModel(m, gfour, (; img, vis))
-end
-
-function set_array(m::FixedSkyModel, array::AbstractArrayConfiguration)
-    return ObservedSkyModel(m, array), NamedTuple()
-end
-
-function idealvisibilities(m::ObservedSkyModel{<:FixedSkyModel}, x)
-    return m.metadata.vis
-end
-
-function skymodel(m::ObservedSkyModel{<:FixedSkyModel}, x)
-    return m.f.model
 end

--- a/src/skymodels/models.jl
+++ b/src/skymodels/models.jl
@@ -1,7 +1,6 @@
 export SkyModel, FixedSkyModel
 
 
-
 struct SkyModel{F, P, G <: AbstractDomain, A <: FourierTransform, M} <: AbstractSkyModel
     f::F
     prior::P
@@ -43,7 +42,6 @@ end
 function VLBISkyModels.FourierDualDomain(grid::AbstractRectiGrid, array::AbstractArrayConfiguration, alg::FourierTransform; executor = Serial())
     return FourierDualDomain(grid, domain(array; executor), alg)
 end
-
 
 
 # If we are using a analytic model then we don't need to plan the FT and we

--- a/src/skymodels/multi.jl
+++ b/src/skymodels/multi.jl
@@ -1,0 +1,68 @@
+export MultiSkyModel
+
+"""
+    MultiSkyModel(skymodels::NamedTuple)
+
+Create a sky model that is a collection of multiple components. This is useful when
+you, e.g., want to decompose the sky into multiple grids, such as for wide-field imaging
+where the is a core component and a very far away component. 
+
+# Arguments
+ - `skymodels` : A named tuple of sky models, where each model is a [`SkyModel`](@ref).
+
+# Example
+```julia
+julia> s1 = SkyModel(...)
+julia> s2 = SkyModel(...)
+julia> stot = MultiSkyModel((core = m1, far = m2))
+julia> skymodel(stot, x)
+(core = ..., far = ...)
+```
+"""
+struct MultiSkyModel{N, T} <: AbstractSkyModel
+    skymodels::NamedTuple{N, T}
+end
+
+function ObservedSkyModel(m::MultiSkyModel, arr::AbstractArrayConfiguration)
+    skymodels = map(m.skymodels) do sm
+        ObservedSkyModel(sm, arr)
+    end
+    return MultiSkyModel(skymodels)
+end
+
+function set_prior(m::MultiSkyModel, array::AbstractArrayConfiguration)
+    prs = map(m.skymodels) do sm
+        set_prior(sm, array)
+    end
+    return prs
+end
+
+function idealvisibilities(m::MultiSkyModel{N}, x) where {N}
+    sm = m.skymodels
+    vis = map(N) do n
+        Base.@_inline_meta
+        @inline idealvisibilities(getproperty(sm, n), (;sky = getproperty(x.sky, n)))
+    end
+    return reduce(+, vis)
+end
+
+function domain(m::MultiSkyModel)
+    return map(m.skymodels) do sm
+        domain(sm)
+    end
+end
+
+function skymodel(m::MultiSkyModel{N}, x) where {N}
+    sm = m.skymodels
+    skyms = map(N) do n
+        Base.@_inline_meta
+        skymodel(getproperty(sm, n), getproperty(x, n))
+    end
+    return NamedTuple{N}(skyms)
+end
+
+function skymodel(m::MultiSkyModel)
+    return map(m.skymodels) do sm
+        skymodel(sm)
+    end
+end

--- a/src/skymodels/multi.jl
+++ b/src/skymodels/multi.jl
@@ -41,7 +41,7 @@ function idealvisibilities(m::MultiSkyModel{N}, x) where {N}
     sm = m.skymodels
     vis = map(N) do n
         Base.@_inline_meta
-        @inline idealvisibilities(getproperty(sm, n), (;sky = getproperty(x.sky, n)))
+        @inline idealvisibilities(getproperty(sm, n), (; sky = getproperty(x.sky, n)))
     end
     return reduce(+, vis)
 end

--- a/test/Core/models.jl
+++ b/test/Core/models.jl
@@ -139,7 +139,7 @@ end
 
 
         x = rand(Comrade.NamedDist(ptot))
-        
+
         oskym, = Comrade.set_array(skym, arrayconfig(vis))
         oskyf, = Comrade.set_array(skyf, arrayconfig(vis))
 


### PR DESCRIPTION
@kazuakiyama this should allow for multiple grids.

Since the Fourier transform strategy is intrinsically is currently attached to the grid, doing this with the standard VLBISkyModels modeling interface won't quite work. There are a few ways around this, one would be to 
create a multigrid object, but that would require a bit of work. The easiest thing I could think of was to just
create a `MultiSkyModel` object that can wrap multiple SkyModels and attach a name to each component.

The interface is something like

```julia
s1 = SkyModel(f1, grid1, metadata1)
s2 = SkyModel(f2, grid2, metadata2)

stot = MultiSkyModel((com1 = s1, com2 = s2))
```
Everything goes through as normal, except that when we query the posterior object we see 
that the different components get their own sky in the named tuple. So

```julia
post = VLBIPosterior(stot, data)
prior_sample(post)
# (sky = (com1 = (...), com2 = (...), )
```

I didn't see any performance hit from doing this so I think it should be alright.

Let me know if this will work for your use case. 
