### PR TITLE
@sky: only store body-referenced kwargs in metadata

### DIFF
--- a/src/skymodels/macro.jl
+++ b/src/skymodels/macro.jl
@@ -133,7 +133,15 @@ function _sky_impl(fexpr)
     prior_fn = Expr(:function, prior_sig, Expr(:block, Expr(:return, prior_nt)))
 
     ctor_sig = Expr(:call, name, Expr(:parameters, kw_args...), grid_arg)
-    metadata_nt = Expr(:tuple, Expr(:parameters, kw_names..., grid_arg))
+    # Only keyword arguments actually referenced by the model body belong in
+    # `metadata`; kwargs used solely on `~` lines are priors and are consumed by
+    # the prior builder. Storing them in metadata needlessly duplicates them and
+    # breaks device transfer for objects Reactant cannot trace (e.g. the
+    # SparseMatrixCSC inside a GMRF `corr_image_prior`). `used_meta` may already
+    # contain `grid_arg`, so drop it before re-appending to avoid a duplicate
+    # NamedTuple field.
+    used_meta_kw = Symbol[n for n in used_meta if n != grid_arg]
+    metadata_nt = Expr(:tuple, Expr(:parameters, used_meta_kw..., grid_arg))
     prior_call = Expr(
         :call, prior_fn_name,
         Expr(:parameters, [Expr(:kw, n, n) for n in prior_required_kwargs]...)


### PR DESCRIPTION
## Summary

The `@sky` macro stored **every** keyword argument in the generated `SkyModel`'s `metadata`, including kwargs that appear *solely* on `~` (prior) lines. Those prior objects are already consumed by the generated prior builder, so duplicating them into `metadata` is wasteful — and it breaks device transfer under Reactant.

Concretely: a `corr_image_prior` is a GMRF carrying a `SparseMatrixCSC`. When `prepare_device` calls `Reactant.to_rarray(m.metadata)`, Reactant cannot trace the sparse matrix and throws `NoFieldMatchError`:

```
Cannot convert type SparseArrays.SparseMatrixCSC{Float64, Int64} ...
  [11] prepare_device(m::Comrade.ObservedSkyModel, ex::ReactantEx)
       @ ComradeReactantExt .../prepare_device.jl:16
```

## Fix

Restrict the `metadata` NamedTuple to `used_meta` — the kwargs the model body actually references — instead of all `kw_names`. `grid_arg` is dropped before re-appending so the grid is never duplicated when the body references it.

```julia
used_meta_kw = Symbol[n for n in used_meta if n != grid_arg]
metadata_nt = Expr(:tuple, Expr(:parameters, used_meta_kw..., grid_arg))
```

Priors remain available to the prior builder (which takes kwargs directly), so behavior is unchanged for sampling/inference — only the redundant metadata entries are removed.

## Verification

Expanding `_sky_impl` on a representative model (priors used only on `~` lines):

- Body uses `ftot, mimg, freq0` → `metadata = (; ftot, mimg, freq0, grid)` — priors `cprior`/`αprior` no longer present.
- Body references the grid → `metadata = (; a, grid)` — no duplicate `grid` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)